### PR TITLE
Loading PyTorch pretrained visual extractors as Env Wrapper

### DIFF
--- a/CHANGELOG_CEAI.md
+++ b/CHANGELOG_CEAI.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [PR#4](https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/4) EnvWrapper for pre-trained torchvision models as feature extractors.
 - [PR#3](https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/3) Loading pre-trained torchvision models as feature extractors.
 - [PR#2](https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/2) Changing the env observation to the rgb_array type with VisualRenderObsWrapper.
 - [PR#1](https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/1) Tracking with MLflow.

--- a/rl_zoo3/wrappers.py
+++ b/rl_zoo3/wrappers.py
@@ -382,7 +382,11 @@ class PreTrainedVisionExtractorWrapper(gym.Wrapper):
     The list: https://pytorch.org/vision/main/models.html .
 
     :param env: the gym environment
-    :param xxx_var: yyy
+    :param model_name: the name of the model in the PascalCase format.
+    :param weights_id: the name of the trained weights (torchvision API).
+    :param cut_on_layer: the name of the layer to cut the head from the backbone.
+    :param use_gpu: the bool for enabling usage of torch cuda device, enabled by default
+    :param result_device: specificies the device for the processed observation (defaults to cpu)
     """
 
     # TODO unify code parts with the feature_extractors
@@ -477,6 +481,9 @@ class PreTrainedVisionExtractorWrapper(gym.Wrapper):
 class ObsToDevice(gym.Wrapper):
     """
     Sends a torch tensor observation to the specified torch device
+    
+    :param env: the gym environment
+    :param device: the torch device
     """
     
     def __init__(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces a new Env Wrapper `PreTrainedVisionExtractorWrapper` for pre-processing visual observations. The idea is similar to https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/3, but differs in the definition of the input for a RL algorithm. Instead of images (which needs to be stored in the buffer and must be processed every time during a training), the algorithm receives only a vector of extracted features.
This should help with long wall-clock times needed for training algorithms.

Please take note, that every env step needs to send image to GPU, process it, take the results back and save it to the RAM.
A performance profiling should be performed before running on intense workloads.    

In addition, a significant usage of GPU VRAM was noticed for greater values of  `n_envs` - this is probably due to multiple allocations of the same model.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
